### PR TITLE
Show fair

### DIFF
--- a/templates/curator.html
+++ b/templates/curator.html
@@ -578,7 +578,7 @@
                     <td>{{sub.date}}</td>
                     <td>{{sub.last_update}}</td>
                     <td>{{sub.status}}</td>
-                    <td>{{sub.fairStatus}}</td>
+                    <td>{{sub.fairStatus|safe}}</td>
                     <td>{{sub.fairScore}}</td>
                     <td>{% if sub.comments %}
                         <button type="button" class="in-table-button abstract-button" id="comments_btn" onclick="showComments(this);"><b>View Comments</b></button>{% endif %}</td>

--- a/templates/curator.html
+++ b/templates/curator.html
@@ -565,6 +565,7 @@
                 <th>Last Update</th>
                 <th>Status</th>
                 <th>FAIR Evaluation</th>
+                <th>FAIR Score</th>
                 <th>Comments</th>
                 <th>Landing Page</th>
                 <th hidden>comments_text</th>
@@ -578,6 +579,7 @@
                     <td>{{sub.last_update}}</td>
                     <td>{{sub.status}}</td>
                     <td>{{sub.fairStatus}}</td>
+                    <td>{{sub.fairScore}}</td>
                     <td>{% if sub.comments %}
                         <button type="button" class="in-table-button abstract-button" id="comments_btn" onclick="showComments(this);"><b>View Comments</b></button>{% endif %}</td>
                     <td>{% if sub.landing_page %} <a target="_blank" href={{sub['landing_page']}} rel="noopener noreferrer">{{sub.landing_page}}</a> {% endif %}</td>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -38,7 +38,7 @@
         <th style="width:30em;">Title</th>
         <th style="width:6em;">Date Created</th>
         <th style="width:6em;">Last Modified</th>
-        <!--<th style="width:6em;">FAIR Evaluation</th>-->
+        <th style="width:6em;">FAIR Evaluation</th>
         <th style="width:17em;">Actions</th>
       </tr>
       {% for d in datasets %}
@@ -46,7 +46,6 @@
           <td>{{d.title}}</td>
           <td>{{d.date_created}}</td>
           <td>{{d.date_modified}}</td>
-          <!--
           <td>{% if fair_eval[d.id] %}
             <table style="border:none;text-align:center;width:100%">
                 <tr>
@@ -56,7 +55,7 @@
                 </tr>
             </table>
             {% else %}TBD{% endif %}
-          </td>-->
+          </td>
           <td><a href="{{url_for('landing_page', dataset_id=d.id)}}">View</a> / <a href="{{url_for('dataset', dataset_id=d.id)}}">Edit</a> / <a href="{{url_for('dataset', template_id=d.id)}}">Create New Submission From This One</a></td>
         </tr>
       {% endfor %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -49,9 +49,9 @@
           <td>{% if fair_eval[d.id] %}
             <table style="border:none;text-align:center;width:100%">
                 <tr>
-                    <td style="border-radius:50px;background-color:red">{{fair_eval[d.id][0]}}</td>
-                    <td style="border-radius:50px;background-color:orange">{{fair_eval[d.id][1]}}</td>
-                    <td style="border-radius:50px;background-color:lightgreen">{{fair_eval[d.id][2]}}</td>
+                    <td title="{{fair_eval[d.id][0]}} {{'aspect' if 1 == fair_eval[d.id][0] else 'aspects'}} rated as &quot;Poor&quot;" style="border-radius:50px;background-color:red">{{fair_eval[d.id][0]}}</td>
+                    <td title="{{fair_eval[d.id][1]}} {{'aspect' if 1 == fair_eval[d.id][1] else 'aspects'}} rated as &quot;Okay&quot;" style="border-radius:50px;background-color:orange">{{fair_eval[d.id][1]}}</td>
+                    <td title="{{fair_eval[d.id][2]}} {{'aspect' if 1 == fair_eval[d.id][2] else 'aspects'}} rated as &quot;Good&quot;" style="border-radius:50px;background-color:lightgreen">{{fair_eval[d.id][2]}}</td>
                 </tr>
             </table>
             {% else %}TBD{% endif %}

--- a/usap.py
+++ b/usap.py
@@ -2426,16 +2426,30 @@ def json_serial(obj):
     """JSON serializer for objects not serializable by default json code"""
     return str(obj)
 
+# determines if the currently logged in user is a creator of the given dataset
+def isCreator(dataset_content):
+    if session.get('user_info') is None:
+        return False
+    userid = session['user_info'].get('sub')
+    if userid is None:
+        userid = session['user_info'].get('orcid')
+    if userid is None:
+        return False
+    if dataset_content.get('creator'):
+        creator_ids = map(lambda x: x.id, dataset_content['creator_orcids'])
+        return userid in creator_ids
+    return False
 
 @app.route('/view/dataset/<dataset_id>')
 def landing_page(dataset_id):
-    review_privilege = False
+    #review_privilege = False
     prev_review = None
     fair_fields = []
     datasets = get_datasets([dataset_id])
     if len(datasets) == 0:
         return redirect(url_for('not_found'))
     metadata = datasets[0]
+    review_privilege = isCreator(metadata)
 
     url = metadata['url']
     if not url:

--- a/usap.py
+++ b/usap.py
@@ -2428,6 +2428,7 @@ def json_serial(obj):
 
 # determines if the currently logged in user is a creator of the given dataset
 def isCreator(dataset_content):
+    print(dataset_content)
     if session.get('user_info') is None:
         return False
     userid = session['user_info'].get('sub')
@@ -2449,7 +2450,7 @@ def landing_page(dataset_id):
     if len(datasets) == 0:
         return redirect(url_for('not_found'))
     metadata = datasets[0]
-    review_privilege = isCreator(metadata)
+    review_privilege = False
 
     url = metadata['url']
     if not url:
@@ -2511,6 +2512,9 @@ def landing_page(dataset_id):
             metadata['creator_orcids'].append({'id': p.get('id'), 'orcid': p.get('id_orcid')}) 
         else:
             metadata['creator_orcids'].append({'id': c, 'orcid': None})
+    
+    if not review_privilege:
+        review_privilege = isCreator(metadata)
 
     if not metadata['citation'] or metadata['citation'] == '':
         metadata['citation'] = makeCitation(metadata, dataset_id)


### PR DESCRIPTION
This update will allow creators of USAP-DC datasets to view their FAIR scores, as evaluated by USAP-DC curators. They will be shown both in summary on the user dashboard and in more detail in a popup on the dataset landing page. Additionally, these scores will show on the curator page, and curators will see (with color coding) which datasets need evaluation or re-evaluation.