### PR TITLE
Updated access log script to not hold all lines in memory at once

### DIFF
--- a/bin/readAccessLogs_with_search.py
+++ b/bin/readAccessLogs_with_search.py
@@ -151,9 +151,10 @@ if __name__ == '__main__':
         print(log_file)
         #log_file = "test.log"
         f = open(log_file, 'r')
-        entries = f.readlines()
+        #entries = f.readlines()
+        entry = f.readline()
         num = 0
-        for entry in entries:
+        while entry:
             log_line_data = line_parser(entry)
             request_url = log_line_data['request_url']
 
@@ -253,6 +254,7 @@ if __name__ == '__main__':
                 except:
                     #entry already exists, do nothing
                     pass
-                cur.execute("COMMIT;")             
+                cur.execute("COMMIT;")
+            entry = f.readline()
 
         print(("%s entries added to the database" % num))


### PR DESCRIPTION
This will hopefully solve the issue with downtime we have nightly at the end of the month, likely due to the log file being held in memory all at once instead of one line at a time.